### PR TITLE
Added Codesplitting to the app [see bellow for improvements]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "query-string": "^6.14.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-loadable": "^5.5.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "react-spring": "^8.0.27",

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -1,28 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import Loader from 'components/Loader';
+import React from 'react';
 import Footer from '../components/Footer';
 import Navbar from '../components/Navbar';
 
 const DefaultLayout = ({ children }) => {
-  const [isMounted, setIsMounted] = useState(true);
-  useEffect(() => {
-    setTimeout(() => {
-      setIsMounted(true);
-    }, 300);
-  }, []);
   return (
-    <>
-      {/* // eslint-disable-next-line no-constant-condition */}
-      {isMounted ? (
-        <div>
-          <Navbar />
-          <div className="page-wrapper">{children}</div>
-          <Footer />
-        </div>
-      ) : (
-        <Loader />
-      )}
-    </>
+    <div>
+      <Navbar />
+      <div className="page-wrapper">{children}</div>
+      <Footer />
+    </div>
   );
 };
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,26 +1,60 @@
 import React, { useReducer, createContext } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import Home from 'pages/index';
-import About from 'pages/about';
-import Dashboard from 'pages/admin/dashboard';
-import Team from 'pages/team';
-import Committee from 'pages/committee';
-import Highlights from 'pages/highlights';
-// eslint-disable-next-line import/no-cycle
-import Registration from 'pages/registration';
+import Loadable from 'react-loadable';
+
 import ROUTES from 'constants/routes';
 import Error from 'pages/error';
 // eslint-disable-next-line import/no-cycle
 import UserCallback from 'pages/google/callback';
-import Login from 'pages/login';
-import AdminLogin from 'pages/admin/login';
-import AmbassdorLogin from 'components/AmbassdorLogin';
+import Loader from 'components/Loader';
 import { initialState, reducer } from 'store/reducers/auth';
-// eslint-disable-next-line import/no-cycle
-import TestPage from 'pages/test';
 
 export const AuthContext = createContext();
+const Home = Loadable({
+  loader: () => import('pages'),
+  loading: Loader,
+});
 
+const About = Loadable({
+  loader: () => import('pages/about'),
+  loading: Loader,
+});
+const Dashboard = Loadable({
+  loader: () => import('pages/admin/dashboard'),
+  loading: Loader,
+});
+const Team = Loadable({
+  loader: () => import('pages/team'),
+  loading: Loader,
+});
+const Committee = Loadable({
+  loader: () => import('pages/committee'),
+  loading: Loader,
+});
+const Highlights = Loadable({
+  loader: () => import('pages/highlights'),
+  loading: Loader,
+});
+const Registration = Loadable({
+  loader: () => import('pages/registration'),
+  loading: Loader,
+});
+const Login = Loadable({
+  loader: () => import('pages/login'),
+  loading: Loader,
+});
+const AdminLogin = Loadable({
+  loader: () => import('pages/admin/login'),
+  loading: Loader,
+});
+const AmbassdorLogin = Loadable({
+  loader: () => import('components/AmbassdorLogin'),
+  loading: Loader,
+});
+const TestPage = Loadable({
+  loader: () => import('pages/test'),
+  loading: Loader,
+});
 const Routes = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9351,7 +9351,7 @@ prompts@2.4.0, prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9595,6 +9595,13 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-loadable@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.5.0.tgz#582251679d3da86c32aae2c8e689c59f1196d8c4"
+  integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
+  dependencies:
+    prop-types "^15.5.0"
 
 react-refresh@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
Route based code splitting added to the app also made a better loader trigger so that we can short loader upon the image load

Goals 
- [x] Make site faster to load
- [x] Deliver Routes in chunks so that we can have a proper Multi-page feel
- [x] Make Loader useful by actually loading stuff in bg 
- [x] Take out loader on load and not on timeout

Outcomes: 

A better splitting of Routes (some components should still be split such as video) see img

**Before Code Split**
![Screen Shot 2021-02-14 at 3 19 07 AM](https://user-images.githubusercontent.com/29141140/107862856-eceb3a80-6e75-11eb-80e9-75914f11467b.png)

**After Code Split**
![Screen Shot 2021-02-14 at 3 17 36 AM](https://user-images.githubusercontent.com/29141140/107862871-02f8fb00-6e76-11eb-83ad-ae37e597745b.png)

**Before**
![Screen Shot 2021-02-14 at 3 35 15 AM](https://user-images.githubusercontent.com/29141140/107862898-1c01ac00-6e76-11eb-98ce-b3507f12a53d.png)

**After**
![Screen Shot 2021-02-14 at 3 34 47 AM](https://user-images.githubusercontent.com/29141140/107862901-2459e700-6e76-11eb-9ea0-4820c30c2acf.png)

